### PR TITLE
Update bullets for channel name change. 

### DIFF
--- a/bullets/mattermost.py
+++ b/bullets/mattermost.py
@@ -37,7 +37,7 @@ def main():
     )
 
     parser.add_argument('markdown_file', type=Path, help='Markdown file with the post content')
-    parser.add_argument('--channel', default='APD', help='The MatterMost channel to post to')
+    parser.add_argument('--channel', default='tools-team', help='The MatterMost channel to post to')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Bullets workflow failed this morning because we changed the `APD` MatterMost channel to `Tools Team`.

I'm not sure if this should be `'Tools Team'` or `tools-team` but, I'm going with the latter because that's how the channel URL is specified:
![image](https://user-images.githubusercontent.com/7882693/150840268-0fba5c4a-d895-4cbe-9376-2822b8de8db8.png)
