### PR TITLE
pin mistune to <2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - jinja2
   - jupyter
   - mattermostdriver
-  - mistune
+  - mistune<2
   - premailer
   - python-dateutil
   - tqdm

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'ghapi',
         'jinja2',
         'mattermostdriver',
-        'mistune',
+        'mistune<2',
         'premailer',
         'python-dateutil',
         'tqdm',


### PR DESCRIPTION
The scheduled bullets run failed Aug 29 and Sep 5 with this exception:
```
Traceback (most recent call last):
  File "/usr/share/miniconda/envs/bullets/bin/sendit", line 8, in <module>
    sys.exit(main())
  File "/usr/share/miniconda/envs/bullets/lib/python3.9/site-packages/bullets/email.py", line 65, in main
    html, text = content(markdown_file=args.markdown_file)
  File "/usr/share/miniconda/envs/bullets/lib/python3.9/site-packages/bullets/email.py", line 20, in content
    markdown2html = mistune.Markdown()
TypeError: __init__() missing 1 required positional argument: 'renderer'
```

Our environment jumped from mistune v0.8.4 to v2.0.4, which includes breaking changes. See https://github.com/lepture/mistune for more information, in particular the "NOTE: This is the re-designed v2 of mistune. Check v1 branch for earlier code." warning near the top of the README.

This PR restricts mistune to `mistune<2`, effectively pinning us to v0.8.4.