### PR TITLE
fix step name in test-and-build.yml workflow

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -25,7 +25,7 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
-    needs: pytest
+    needs: call-pytest-workflow
     outputs:
       SDIST_VERSION:  ${{ steps.build.outputs.version }}
     steps:


### PR DESCRIPTION
The name of the pytest step changed from `pytest` to `call-pytest-workflow` in https://github.com/ASFHyP3/bullets/commit/dfb455223a32375e5a7eea46bfc0296542af1a2b when adopting re-useable actions, but the reference in the `package` step wasn't updated to match