### PR TITLE
Cut over to micromamba

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.7.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.7.0
     with:
       release_prefix: Tools Team Bullets
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,9 +4,9 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.7.0
     with:
       local_package_names: bullets
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.7.0

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.7.0
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,7 @@ on:
 
 jobs:
   call-pytest-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.0
     with:
       local_package_name: bullets
-      conda_env_name: bullets
-      python_version: '3.9'
+      python_version: '3.10'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,5 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.0
     with:
       local_package_name: bullets
-      python_versions: ['3.10']
+      python_versions: >-
+        ["3.10"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
     uses: ASFHyP3/actions/.github/workflows/reusable-pytest.yml@v0.7.0
     with:
       local_package_name: bullets
-      python_version: '3.10'
+      python_versions: ['3.10']

--- a/.github/workflows/weekly_bullets.yml
+++ b/.github/workflows/weekly_bullets.yml
@@ -32,12 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: mamba-org/provision-with-micromamba@v14
         with:
-          mamba-version: "*"
-          python-version: 3.9
-          activate-environment: bullets
-          environment-file: environment.yml
+          extra-specs: |
+            python=3.10
 
       - name: Install bullets
         shell: bash -l {0}

--- a/.github/workflows/weekly_bullets.yml
+++ b/.github/workflows/weekly_bullets.yml
@@ -33,9 +33,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: mamba-org/provision-with-micromamba@v14
-        with:
-          extra-specs: |
-            python=3.10
 
       - name: Install bullets
         shell: bash -l {0}

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip
   # For running
   - boto3


### PR DESCRIPTION
Bullets have been failing because micromamba environment solve is broken.

This:
* upgrades reusable actions to 0.7.0 for micromamba
* drops mimiconda for micromamba
* bumps python to 3.10

<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/bullets/compare/main...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->